### PR TITLE
Update python-jsonlogger imports and pytest asyncio config

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_default_fixture_loop_scope = function 

--- a/src/mockllm/config.py
+++ b/src/mockllm/config.py
@@ -6,10 +6,10 @@ from typing import AsyncGenerator, Dict, Generator, Optional
 
 import yaml
 from fastapi import HTTPException
-from pythonjsonlogger import jsonlogger
+from pythonjsonlogger.json import JsonFormatter
 
 log_handler = logging.StreamHandler()
-log_handler.setFormatter(jsonlogger.JsonFormatter())
+log_handler.setFormatter(JsonFormatter())
 logging.basicConfig(level=logging.INFO, handlers=[log_handler])
 logger = logging.getLogger(__name__)
 
@@ -53,7 +53,7 @@ class ResponseConfig:
     def get_response(self, prompt: str) -> str:
         """Get response for a given prompt."""
         self.load_responses()  # Check for updates
-        return self.responses.get(prompt , self.default_response)
+        return self.responses.get(prompt, self.default_response)
 
     def get_streaming_response(
         self, prompt: str, chunk_size: Optional[int] = None

--- a/src/mockllm/server.py
+++ b/src/mockllm/server.py
@@ -4,7 +4,7 @@ from typing import Any, AsyncGenerator, Dict, Union
 import tiktoken
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import StreamingResponse
-from pythonjsonlogger import jsonlogger
+from pythonjsonlogger.json import JsonFormatter
 
 from .config import ResponseConfig
 from .models import (
@@ -20,7 +20,7 @@ from .providers.anthropic import AnthropicProvider
 from .providers.openai import OpenAIProvider
 
 log_handler = logging.StreamHandler()
-log_handler.setFormatter(jsonlogger.JsonFormatter())
+log_handler.setFormatter(JsonFormatter())
 logging.basicConfig(level=logging.INFO, handlers=[log_handler])
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Update python-json-logger imports and pytest asyncio config

- Update deprecated imports from pythonjsonlogger.jsonlogger to pythonjsonlogger.json in server.py and config.py
- Add pytest.ini with asyncio_default_fixture_loop_scope setting to address pytest-asyncio deprecation warning

These changes resolve deprecation warnings that were complaining when running unit tests